### PR TITLE
Add support for the OctoEconomyAPI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ group = project.maven_group
 repositories {
     maven { url "https://maven.shedaniel.me/" }
 	maven { url "https://maven.terraformersmc.com/releases/" }
+	maven { url "https://jitpack.io" }
 }
 
 loadProperties()
@@ -35,6 +36,7 @@ dependencies {
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+	modImplementation "com.github.ExcessiveAmountsOfZombies:OctoEconomyApi:5137175b1c"
 
 	modRuntimeOnly modImplementation("com.terraformersmc:modmenu:3.0.0")
 

--- a/src/main/java/dev/fulmineo/guild/EconomyDependency.java
+++ b/src/main/java/dev/fulmineo/guild/EconomyDependency.java
@@ -1,0 +1,69 @@
+package dev.fulmineo.guild;
+
+
+import com.epherical.octoecon.api.Currency;
+import com.epherical.octoecon.api.Economy;
+import com.epherical.octoecon.api.user.UniqueUser;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.entity.effect.StatusEffects;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.Identifier;
+
+import java.util.UUID;
+
+public class EconomyDependency {
+
+	private Economy economy;
+
+	public EconomyDependency(Economy economy) {
+		this.economy = economy;
+	}
+
+	public String validateCurrency(String currency) {
+		String addError = "";
+		if (economy == null) {
+			addError = currency + " No economy installed";
+		} else if (economy.getCurrency(new Identifier(currency)) == null || economy.getDefaultCurrency() == null) {
+			addError = currency + " Incorrect currency";
+		}
+		return addError;
+	}
+
+	public void giveReward(boolean expired, NbtCompound entry, ServerPlayerEntity player) {
+		int count = entry.getInt("Count");
+		if (expired) {
+			int cnt1 = player.world.random.nextInt(count + 1);
+			if (player.hasStatusEffect(StatusEffects.LUCK)) {
+				int cnt2 = player.world.random.nextInt(count + 1);
+				count = Math.max(cnt1, cnt2);
+			} else {
+				count = cnt1;
+			}
+		}
+		Currency currency = economy.getCurrency(new Identifier(entry.getString("Name")));
+		if (currency == null) {
+			currency = economy.getDefaultCurrency();
+		}
+		UUID playerID = player.getUuid();
+		UniqueUser user = economy.getOrCreatePlayerAccount(playerID);
+		if (user != null) {
+			user.depositMoney(currency, count, "Guild reward");
+		}
+	}
+	@Environment(EnvType.CLIENT)
+	public void addRewardName(ItemStack stack, NbtCompound entry) {
+		Currency currency = economy.getCurrency(new Identifier(entry.getString("Name")));
+		if (currency == null) {
+			currency = economy.getDefaultCurrency();
+		}
+		int amount = entry.getInt("Count");
+		if (amount > 1) {
+			stack.setCustomName(currency.getCurrencyPluralName());
+		} else {
+			stack.setCustomName(currency.getCurrencySingularName());
+		}
+	}
+}

--- a/src/main/java/dev/fulmineo/guild/Guild.java
+++ b/src/main/java/dev/fulmineo/guild/Guild.java
@@ -4,6 +4,7 @@ import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.client.itemgroup.FabricItemGroupBuilder;
 import net.fabricmc.fabric.api.item.v1.FabricItemSettings;
 import net.fabricmc.fabric.api.screenhandler.v1.ScreenHandlerRegistry;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.block.AbstractBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
@@ -35,6 +36,7 @@ import dev.fulmineo.guild.network.ServerNetworkManager;
 import dev.fulmineo.guild.screen.QuestsScreenHandler;
 import me.shedaniel.autoconfig.AutoConfig;
 import me.shedaniel.autoconfig.serializer.JanksonConfigSerializer;
+import org.jetbrains.annotations.Nullable;
 
 public class Guild implements ModInitializer {
 
@@ -48,6 +50,9 @@ public class Guild implements ModInitializer {
 	// Global variables
 
 	public static List<String> errors = new ArrayList<>();
+	public static boolean OCTO_ECON_API_LOADED = false;
+	@Nullable
+	public static EconomyDependency economyDependency;
 
     // Identifiers
 
@@ -87,6 +92,10 @@ public class Guild implements ModInitializer {
     public void onInitialize() {
 		AutoConfig.register(GuildConfig.class, JanksonConfigSerializer::new);
 		CONFIG = AutoConfig.getConfigHolder(GuildConfig.class).getConfig();
+
+		// Global Variables
+
+		OCTO_ECON_API_LOADED = FabricLoader.getInstance().isModLoaded("octo-economy-api");
 
 		// Blocks
 

--- a/src/main/java/dev/fulmineo/guild/data/QuestPoolData.java
+++ b/src/main/java/dev/fulmineo/guild/data/QuestPoolData.java
@@ -1,5 +1,6 @@
 package dev.fulmineo.guild.data;
 
+import dev.fulmineo.guild.Guild;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
@@ -45,6 +46,13 @@ public class QuestPoolData implements WeightedItem {
 			}
 			case "slay", "summon", "cure": {
 				if (Registry.ENTITY_TYPE.containsId(new Identifier(name))) return "";
+			}
+			case "currency": {
+				if (Guild.economyDependency != null) {
+					return Guild.economyDependency.validateCurrency(name);
+				} else {
+					return name + " no economy installed";
+				}
 			}
 		}
 		return name;

--- a/src/main/java/dev/fulmineo/guild/init/ServerEventInit.java
+++ b/src/main/java/dev/fulmineo/guild/init/ServerEventInit.java
@@ -2,6 +2,9 @@ package dev.fulmineo.guild.init;
 
 import java.util.List;
 
+import com.epherical.octoecon.api.event.EconomyEvents;
+import dev.fulmineo.guild.EconomyDependency;
+import dev.fulmineo.guild.Guild;
 import dev.fulmineo.guild.network.ServerNetworkManager;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.minecraft.nbt.NbtCompound;
@@ -20,5 +23,10 @@ public class ServerEventInit {
 				}
 			}
 		});
+		if (Guild.OCTO_ECON_API_LOADED) {
+			EconomyEvents.ECONOMY_CHANGE_EVENT.register(economy -> {
+				Guild.economyDependency = new EconomyDependency(economy);
+			});
+		}
 	}
 }


### PR DESCRIPTION
Hello

I wrote an Economy API and am now looking to integrate it into other mods where it makes sense to do so. I remember seeing Guild in the Fabric discord and thought it might be a nice place to start.

You can find the API here
https://github.com/ExcessiveAmountsOfZombies/OctoEconomyApi
and an implementation here if you'd like to test things
https://www.curseforge.com/minecraft/mc-mods/eightseconomyp

I just edited the common_rewards loot pool like so to test and see if it worked
```
{
	"type": "currency",
	"icon": "minecraft:emerald",
	"name": "eights_economy:dollars",
	"number": {
		"min": 3,
		"max": 320
	},
	"unit_worth": 5,
	"weight": 100
},
```
A caveat I came across is after removing the economy and editing the datapack to remove the currency type reward, the quest would stay and when completed would give nothing, while appearing to say it would give a reward. Not sure how you'd like that handled, or if you would like to handle it yourself. Maybe it's not even worth handling seeing as removing a content mod and its subsequent rewards would do the same thing. Can also hide the entire 'issue' by making the icon air.
